### PR TITLE
Define custom Prometheus clients

### DIFF
--- a/roles/grafana/tasks/install.yml
+++ b/roles/grafana/tasks/install.yml
@@ -20,6 +20,7 @@
     name: "{{ container_service_name }}"
     state: started
     enabled: true
+  retries: 3
 
 - name: Wait for port {{ host_port }} to be up
   ansible.builtin.wait_for:

--- a/roles/grafana/tasks/uninstall.yml
+++ b/roles/grafana/tasks/uninstall.yml
@@ -25,3 +25,4 @@
   containers.podman.podman_volume:
     name: "{{ volume_name }}"
     state: absent
+  retries: 3

--- a/roles/node-exporter/tasks/install.yml
+++ b/roles/node-exporter/tasks/install.yml
@@ -16,3 +16,4 @@
     name: "{{ container_service_name }}"
     state: started
     enabled: true
+  retries: 3

--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -45,3 +45,4 @@
     name: "{{ container_service_name }}"
     state: started
     enabled: true
+  retries: 3

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -9,9 +9,15 @@ scrape_configs:
   - job_name: node-exporter
     static_configs:
       - targets:
-{% for host in groups['node_exporter'] %}
+{% if clients is defined %}
+{%   for host in clients %}
         - {{ host }}:9100
-{% endfor %}
+{%   endfor %}
+{% else %}
+{%   for host in groups['node_exporter'] %}
+        - {{ host }}:9100
+{%   endfor %}
+{% endif %}
     relabel_configs:
       - source_labels: [__address__]
         regex: '(.+):(\d+)'


### PR DESCRIPTION
By default, all hosts in the node_exporter group are added to each Prometheus host. When more than one Prometheus instance is configured (for example in multisite environments), it makes sense to configure a custom list of targets in each one, instead of the whole list.